### PR TITLE
Copy over firstname,lastname changes to name field

### DIFF
--- a/app/decorators/models/solidus_address_name/address_decorator.rb
+++ b/app/decorators/models/solidus_address_name/address_decorator.rb
@@ -8,24 +8,18 @@ module SolidusAddressName
       base.alias_attribute :full_name, :name
 
       base.ignored_columns = []
+
       if base.method_defined?(:allowed_ransackable_attributes)
         base.allowed_ransackable_attributes.push(:firstname, :lastname)
       else
         base.whitelisted_ransackable_attributes.push(:firstname, :lastname)
       end
+
+      base.before_save :copy_split_name
     end
 
-    def name
-      "#{firstname} #{lastname}".strip
-    end
-
-    def name=(value)
-      return if value.nil?
-
-      name_from_value = Spree::Address::Name.new(value)
-      write_attribute(:firstname, name_from_value.first_name)
-      write_attribute(:lastname, name_from_value.last_name)
-      write_attribute(:name, value)
+    def copy_split_name
+      self.name = "#{firstname} #{lastname}".strip
     end
 
     Spree::Address.prepend(self)


### PR DESCRIPTION
This will allow us to maintain forward compatibility with Solidus changes. 
It will still maintain changes on all the available name fields.