### PR TITLE
Remove Deprecation Warnings from Solidus 2.11

### DIFF
--- a/app/decorators/solidus_address_name/active_support/deprecation_decorator.rb
+++ b/app/decorators/solidus_address_name/active_support/deprecation_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module DeprecationDecorator
+    def warn(message = nil, callstack = caller)
+      if Spree.solidus_gem_version < Gem::Version.new('3.0')
+        return if message == 'firstname is deprecated and will be removed from Solidus 3.0 (use name instead)'
+        return if message == 'lastname is deprecated and will be removed from Solidus 3.0 (use name instead)'
+        return if message == 'full_name is deprecated and will be removed from Solidus 3.0 (use name instead)'
+      end
+
+      super
+    end
+
+    ::ActiveSupport::Deprecation.prepend self
+  end
+end

--- a/spec/models/active_support/deprecation_spec.rb
+++ b/spec/models/active_support/deprecation_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActiveSupport::Deprecation, type: :model do
+  describe '.warn' do
+    subject { described_class.warn(message) }
+
+
+    before { allow(Spree).to receive(:solidus_gem_version).and_return(solidus_version) }
+
+    [:firstname, :lastname, :full_name].each do |method|
+      context 'when solidus version is lower than 3.0' do
+        let(:solidus_version) { Gem::Version.new('2.11.17') }
+
+        context "#{method}" do
+          let(:message) { "#{method} is deprecated and will be removed from Solidus 3.0 (use name instead)" }
+
+          it "suppress warn for Spree::Address##{method} deprecation" do
+            is_expected.to be_nil
+          end
+        end
+      end
+
+      context 'when solidus version is not lower than 3.0' do
+        let(:solidus_version) { Gem::Version.new('3.0.0') }
+
+        context "#{method}" do
+          let(:message) { "#{method} is deprecated and will be removed from Solidus 3.0 (use name instead)" }
+
+          it "does not suppress warn for Spree::Address##{method} deprecation" do
+            is_expected.not_to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Solidus 2.11 gives deprecation warnings even after adding this extension to the project.

This is not required as we are supporting the old functionality in this extension and hence the deprecation warning should also be removed.