### PR TITLE
Revert changed address factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ You can load Solidus core factories along with this extension's factories using 
 SolidusDevSupport::TestingSupport::Factories.load_for(SolidusAddressName::Engine)
 ```
 
+or, if you're not using `SolidusDevSupport`:
+
+```ruby
+require 'solidus_address_name/testing_support/factories'
+```
+
 ### Running the sandbox
 
 To run this extension in a sandboxed Solidus application, you can run `bin/sandbox`. The path for

--- a/lib/solidus_address_name/testing_support/factories.rb
+++ b/lib/solidus_address_name/testing_support/factories.rb
@@ -1,4 +1,17 @@
 # frozen_string_literal: true
 
+FactoryBot.modify do
+  # Revert the firstname and lastname to their original values before
+  # https://github.com/solidusio/solidus/pull/3584/files#diff-8e88fbe32e58692ffaf3629a7fdfdadfa4378dd248a011fc8d2d266a5ed299a4
+  factory :address do
+    transient do
+      name { nil }
+    end
+
+    firstname { 'John' }
+    lastname { nil }
+  end
+end
+
 FactoryBot.define do
 end

--- a/spec/models/spree/address_spec.rb
+++ b/spec/models/spree/address_spec.rb
@@ -300,4 +300,16 @@ RSpec.describe Spree::Address, type: :model do
 
     it { is_expected.to be_require_phone }
   end
+
+  context 'when using address factory' do
+    let(:address) { build(:address) }
+
+    it 'has John as first_name' do
+      expect(address.firstname).to eq 'John'
+    end
+
+    it 'has a nil last_name' do
+      expect(address.lastname).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
In solidusio/solidus#3584, they [changed the address factory](https://github.com/solidusio/solidus/pull/3584/files#diff-8e88fbe32e58692ffaf3629a7fdfdadfa4378dd248a011fc8d2d266a5ed299a4), so the `firstname` and `lastname` will differ from the previous version.

This commits reverts the changes, so if in your applications test you're using the old address factory, the specs will continue to work properly.